### PR TITLE
Revert golang from v1.22 to v1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/activecm/rita-legacy
 
-go 1.22
+go 1.17
 
 // If urfave/cli is updated from v1.20.0 the corresponding autocomplete file
 // should be updated in etc/bash_completion.d/rita-legacy

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/activecm/mgorus v0.1.1 h1:v+DoSPWbbaNkwrJDwHI+nh0K7xEqktahimoWeo0jCOc=
 github.com/activecm/mgorus v0.1.1/go.mod h1:oCz/dUji4JsFLsc1EKfgsotg20uITyvjblxo1ieo8Bg=
+github.com/activecm/mgosec v0.1.1/go.mod h1:XcwqX1en4L7Tfxd6r6NdstZt/cbArEg8OBZyUKf9HtU=
 github.com/activecm/mgosec v0.1.2-0.20191108195135-d918492993da h1:LXRJgg7iscvGezPD5CMWNaJDlmKd3r8gyEGMecIERWI=
 github.com/activecm/mgosec v0.1.2-0.20191108195135-d918492993da/go.mod h1:XcwqX1en4L7Tfxd6r6NdstZt/cbArEg8OBZyUKf9HtU=
 github.com/activecm/rita-bl v0.0.0-20220823191806-f014db21453d h1:chJrld/x2Q+3Uj/3TrkHTKIe4gcN7x9tSIAIrxcZIOQ=
@@ -13,8 +14,10 @@ github.com/creasty/defaults v1.3.0/go.mod h1:CIEEvs7oIVZm30R8VxtFJs+4k201gReYyuY
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20190517090918-73267e130ca1 h1:DQs0vsFrJDNGZovxiwBtuUaL0SLrQeNHkHpsIbi7w8U=
 github.com/globalsign/mgo v0.0.0-20190517090918-73267e130ca1/go.mod h1:OQBK0ebL25cW31topLSUPIWIrSesue7+zTa/haAXccQ=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -22,6 +25,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/safebrowsing v0.0.0-20171128203709-fe6951d7ef01/go.mod h1:5s5M4BFXyqfUstbiDH1ClnS7VmZmDqUaY/X0Rqbfw3o=
 github.com/google/safebrowsing v0.0.0-20190214191829-0feabcc2960b h1:VnwTdca7ctu+Z5+ljDDtNUPVJmDbCOkWvQONMdSf+qs=
 github.com/google/safebrowsing v0.0.0-20190214191829-0feabcc2960b/go.mod h1:5s5M4BFXyqfUstbiDH1ClnS7VmZmDqUaY/X0Rqbfw3o=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
@@ -68,10 +72,12 @@ github.com/vbauerster/mpb v3.3.4+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI7
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20180712202826-d0887baf81f4/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Tests were still running with go v1.17, which ended up masking an issue with linting on v1.22. This PR reverts changes made to go.mod/go.sum. Verified that building with go v1.17 works and that all tests pass as before.